### PR TITLE
Improved Arlo arm when time to sleep

### DIFF
--- a/config/component/binary_sensor/bayesian.yaml
+++ b/config/component/binary_sensor/bayesian.yaml
@@ -1,0 +1,35 @@
+- platform: bayesian
+  prior: 0.1
+  name: 'Bayesian Sleeping'
+  probability_threshold: 0.95
+  observations:
+      - entity_id: 'group.location'
+        prob_given_true: 0.5
+        prob_given_false: 0.2
+        platform: 'state'
+        to_state: 'home'
+      - entity_id: 'sun.sun'
+        prob_given_true: 0.7
+        prob_given_false: 0.3
+        platform: 'state'
+        to_state: 'below_horizon'
+      - entity_id: 'group.all_lights'
+        prob_given_true: 0.5
+        prob_given_false: 0.2
+        platform: 'state'
+        to_state: 'off'
+      - entity_id: 'media_player.lg_tv'
+        prob_given_true: 0.3
+        prob_given_false: 0.1
+        platform: 'state'
+        to_state: 'off'
+      - entity_id: 'media_player.sony_tv'
+        prob_given_true: 0.2
+        prob_given_false: 0.1
+        platform: 'state'
+        to_state: 'off'
+      - entity_id: 'switch.arlec_switch_3'
+        prob_given_true: 0.9
+        prob_given_false: 0.1
+        platform: 'state'
+        to_state: 'on'

--- a/config/etc/automation/arlo.yaml
+++ b/config/etc/automation/arlo.yaml
@@ -1,16 +1,20 @@
 - id: arm_away_arlo_night
   alias: Arm Away at night
   trigger:
-    platform: time
-    at: '23:00:00'
+    platform: state
+    entity_id: binary_sensor.bayesian_sleeping
+    from: 'off'
+    to: 'on'
   action:
     service: alarm_control_panel.alarm_arm_away
     entity_id: alarm_control_panel.home
 - id: arm_home_arlo_morning
   alias: Arm Home in morning
   trigger:
-    platform: time
-    at: '06:00:00'
+    platform: state
+    entity_id: binary_sensor.bayesian_sleeping
+    from: 'on'
+    to: 'off'
   action:
     service: alarm_control_panel.alarm_arm_home
     entity_id: alarm_control_panel.home

--- a/config/interface/group.yaml
+++ b/config/interface/group.yaml
@@ -268,6 +268,7 @@ people:
     - device_tracker.tegan_nexus_6p
     - sensor.tegan_address
     - sensor.tegan_phone_battery
+    - binary_sensor.bayesian_sleeping
 ### WORK TRAVEL GROUP ###
 travel_time:
   name: Travel time

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -47,6 +47,7 @@ binary_sensor: !include_dir_merge_list config/component/binary_sensor
 notify: !include_dir_merge_list config/component/notify
 google_assistant: !include_dir_merge_named config/component/google_assistant
 weather: !include_dir_merge_list config/component/weather
+sun:
 mqtt:
   broker: !secret mqtt_broker
   port: !secret mqtt_port


### PR DESCRIPTION
Attempt to make sure of [bayesian binary sensor](https://home-assistant.io/components/binary_sensor.bayesian/) to detect when to arm away or arm home Arlo. Currently it is just time based