### PR TITLE
Setup additional Broadlink Pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Home Assistant Version: 0.62.1
 | ----- | ----------------------------------------------------- | ---- |
 | 3     | Arlec Remote Controlled Power Outlet                  | [(Bunnings)](https://www.bunnings.com.au/arlec-remote-controlled-power-outlet_p4331763) |
 | 1     | Broadlink RM Mini 3                                   | [(eBay)](https://www.ebay.com.au/sch/i.html?_odkw=broadlink+rm+mini+3&_osacat=0&_from=R40&_trksid=p2045573.m570.l1313.TR0.TRC0.H0.TRS0&_nkw=broadlink+rm+mini+3&_sacat=0) |
-| 1     | Broadlink RM Pro                                      | [(eBay)](https://www.ebay.com.au/sch/i.html?_odkw=broadlink+rm+pro+3&_osacat=0&_from=R40&_trksid=p2045573.m570.l1313.TR3.TRC2.A0.H0.Xbroadlink+rm+pro.TRS0&_nkw=broadlink+rm+pro&_sacat=0) |
+| 2     | Broadlink RM Pro                                      | [(eBay)](https://www.ebay.com.au/sch/i.html?_odkw=broadlink+rm+pro+3&_osacat=0&_from=R40&_trksid=p2045573.m570.l1313.TR3.TRC2.A0.H0.Xbroadlink+rm+pro.TRS0&_nkw=broadlink+rm+pro&_sacat=0) |
 | 10    | flic smart button                                     | [(flic)](https://flic.io/shop/flic-1pack) |
 | 1     | Xiaomi button                                         | [(GearBest)](https://www.gearbest.com/alarm-systems/pp_616359.html) |
 | 1     | Xiaomi Door and Window sensor                         | [(GearBest)](https://www.gearbest.com/alarm-systems/pp_616359.html) |

--- a/config/component/climate/broadlink.yaml
+++ b/config/component/climate/broadlink.yaml
@@ -1,12 +1,12 @@
 - platform: broadlink
   name: Sharp Split System
-  host: !secret broadlink_mini_host
-  mac: !secret broadlink_mini_mac
+  host: !secret broadlink_living_room_host
+  mac: !secret broadlink_living_room_mac
   ircodes_ini: 'config/component/climate/broadlink_climate_codes/sharp_split_system.ini'
   min_temp: 20
   max_temp: 26
-  target_temp: 23
-  temp_sensor: sensor.broadlink_sensor_temperature
+  target_temp: 24
+  temp_sensor: sensor.temperature_158d000201d596
   default_operation: 'off'
   default_fan_mode: auto
   customize:

--- a/config/component/fan/broadlink.yaml
+++ b/config/component/fan/broadlink.yaml
@@ -1,7 +1,7 @@
 - platform: broadlink
   name: Lounge
-  host: !secret broadlink_pro_host
-  mac: !secret broadlink_pro_mac
+  host: !secret broadlink_lounge_room_host
+  mac: !secret broadlink_lounge_room_mac
   rfcodes_ini: 'config/component/fan/broadlink_fan_codes/heller_fan.ini'
   default_speed: low-swing
   defaut_direction: left

--- a/config/component/media_player/broadlink.yaml
+++ b/config/component/media_player/broadlink.yaml
@@ -1,12 +1,12 @@
 - platform: broadlink
   name: Sony TV
-  host: !secret broadlink_mini_host
-  mac: !secret broadlink_mini_mac
+  host: !secret broadlink_living_room_host
+  mac: !secret broadlink_living_room_mac
   ircodes_ini: 'config/component/media_player/broadlink_media_codes/sony_tv.ini'
   ping_host: !secret broadlink_sony_tv_ping_host
 - platform: broadlink
   name: LG TV
-  host: !secret broadlink_pro_host
-  mac: !secret broadlink_pro_mac
+  host: !secret broadlink_lounge_room_host
+  mac: !secret broadlink_lounge_room_mac
   ircodes_ini: 'config/component/media_player/broadlink_media_codes/lg_tv.ini'
   ping_host: !secret broadlink_lg_tv_ping_host

--- a/config/component/sensor/broadlink.yaml
+++ b/config/component/sensor/broadlink.yaml
@@ -1,6 +1,7 @@
 - platform: broadlink
+  name: Broadlink Lounge Room
   update_interval: 60
-  host: !secret broadlink_pro_host
-  mac: !secret broadlink_pro_mac
+  host: !secret broadlink_lounge_room_host
+  mac: !secret broadlink_lounge_room_mac
   monitored_conditions:
     - temperature

--- a/config/component/switch/broadlink.yaml
+++ b/config/component/switch/broadlink.yaml
@@ -1,8 +1,8 @@
 - platform: broadlink
-  host: !secret broadlink_pro_host
-  mac: !secret broadlink_pro_mac
+  host: !secret broadlink_lounge_room_host
+  mac: !secret broadlink_lounge_room_mac
   timeout: 15
-  friendly_name: RM Pro
+  friendly_name: RM Pro Lounge Room
   switches:
     # Arlec Switches
     arlec_switch_1:
@@ -17,6 +17,11 @@
       friendly_name: "Arlec Switch 3"
       command_on: !secret switch_arlec_3_command_on
       command_off: !secret switch_arlec_3_command_off
+- platform: broadlink
+  host: !secret broadlink_living_room_host
+  mac: !secret broadlink_living_room_mac
+  timeout: 15
+  friendly_name: RM Pro Living Room
 - platform: broadlink
   host: !secret broadlink_mini_host
   mac: !secret broadlink_mini_mac

--- a/config/core/packages/twitter.yaml
+++ b/config/core/packages/twitter.yaml
@@ -171,7 +171,7 @@ automation:
             "The Pi has been running for {{states.sensor.since_last_boot_templated.state}}",
             "I am running Home Assistant version {{states.sensor.current_version.state}} (https://github.com/Zac300/Home-Assistant-Config)",
             "#Arlo captured {{states.sensor.captured_today_backyard.state}} backyard events in the last 24 hours.",
-            "Outside is {{states.sensor.dark_sky_temperature.state}}{{states.sensor.dark_sky_apparent_temperature.attributes.unit_of_measurement}}. Currently inside the temperature is {{states.sensor.broadlink_sensor_temperature.state}}{{states.sensor.broadlink_sensor_temperature.attributes.unit_of_measurement}}.",
+            "Outside is {{states.sensor.dark_sky_temperature.state}}{{states.sensor.dark_sky_apparent_temperature.attributes.unit_of_measurement}}. Currently inside the temperature is {{states.sensor.temperature_158d000201d596.state}}{{states.sensor.temperature_158d000201d596.attributes.unit_of_measurement}}.",
             "My Average #iiNet internet speeds are Download: {{states.sensor.speedtest_download.state}} Mbit/s & Upload {{states.sensor.speedtest_upload.state}} Mbit/s. #NBN",
             "Home Assistant has been running for {{states.sensor.uptime.state}} days. (https://github.com/Zac300/Home-Assistant-Config)",
             "So far, I have prevented {{states.sensor.pihole_ads_blocked_today.state}} ads from hitting the network via Pi-hole! http://www.pi-hole.net",

--- a/config/core/packages/xiaomi.yaml
+++ b/config/core/packages/xiaomi.yaml
@@ -21,7 +21,7 @@ group:
       - binary_sensor.door_window_sensor_158d0001f366fe
       - binary_sensor.motion_sensor_158d00016573cb
       - sensor.temperature_158d000201d596
-
+      - sensor.humidity_158d000201d596
 
 homeassistant:
   customize:
@@ -42,3 +42,6 @@ homeassistant:
 
     sensor.temperature_158d000201d596:
       friendly_name: Xiaomi Temperature Sensor
+
+    sensor.humidity_158d000201d596:
+      friendly_name: Xiaomi Humidity Sensor

--- a/config/interface/group.yaml
+++ b/config/interface/group.yaml
@@ -89,6 +89,8 @@ lounge_hall:
    - device_tracker.lounge_chromecast_tv
    - device_tracker.lounge_chromecast_soundbar
    - device_tracker.lounge_google_home
+   - sensor.broadlink_lounge_room_temperature
+   - binary_sensor.door_window_sensor_158d0001f366fe
 kitchen_sink:
  name: Kitchen Sink
  entities:
@@ -102,17 +104,21 @@ kitchen_living:
   - light.sink_left
   - light.sink_centre
   - light.sink_right
+  - light.gateway_light_7811dcb065a1
   - device_tracker.sony_tv
   - device_tracker.elgato_eyetv
   - device_tracker.living_chromecast_tv
   - device_tracker.bw_a7
   - device_tracker.kitchen_chromecast_speaker
+  - sensor.temperature_158d000201d596
+  - sensor.humidity_158d000201d596
 bedroom:
  name: Bedroom
  entities:
   - light.bedside_lamp
   - light.bedroom
   - switch.arlec_switch_3
+  - switch.plug_158d00019d4661
 all_lights:
  name: All Lights
  entities:
@@ -126,6 +132,7 @@ all_lights:
   - light.hallway
   - light.bedroom
   - light.bedside_lamp
+  - light.gateway_light_7811dcb065a1
 arlo:
  name: Arlo
  entities:


### PR DESCRIPTION
Once the additional Broadlink RM Pro has arrived, replace current Mini configuration to use RM Pro, mini will be repurposed at a later date.