### PR TITLE
Update to 0.63.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 This is my [Home Assistant](https://home-assistant.io) configuration which is running on a [Raspberry PI 3 ](http://au.element14.com/buy-raspberry-pi?&CMP=KNC-GAU-GEN-SKU-PSP-STL-RPI3&mckv=szEgWGgK7_dc%7Cpcrid%7C238407451184%7Cpkw%7C%2Belement14%20%2Bpi%20%2B3%7Cpmt%7Cb%7Cslid%7CE0QUwafP%7Cproduct%7C%7C&gclid=Cj0KCQiAyZLSBRDpARIsAH66VQK5HeckMfiD1iPzSbrMpRJeNTs-IJuUHgCkgFjuTeIZmITQ4rQ6WF0aAnQQEALw_wcB) using a [Hassbian](https://home-assistant.io/docs/installation/hassbian/installation/) image.
 
-Home Assistant Version: 0.63.2
+Home Assistant Version: 0.63.3
 
 ## Platform
 * [Raspberry PI 3 Model B](http://au.element14.com/buy-raspberry-pi?&CMP=KNC-GAU-GEN-SKU-PSP-STL-RPI3&mckv=szEgWGgK7_dc%7Cpcrid%7C238407451184%7Cpkw%7C%2Belement14%20%2Bpi%20%2B3%7Cpmt%7Cb%7Cslid%7CE0QUwafP%7Cproduct%7C%7C&gclid=Cj0KCQiAyZLSBRDpARIsAH66VQK5HeckMfiD1iPzSbrMpRJeNTs-IJuUHgCkgFjuTeIZmITQ4rQ6WF0aAnQQEALw_wcB)


### PR DESCRIPTION
Refer to release notes [here](https://home-assistant.io/blog/2018/02/10/release-63/#release-0633---february-17).

Can remove cast of brightness to int in light template