### PR TITLE
Upgrade to 0.66

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 This is my [Home Assistant](https://home-assistant.io) configuration which is running on a [Raspberry PI 3 ](http://au.element14.com/buy-raspberry-pi?&CMP=KNC-GAU-GEN-SKU-PSP-STL-RPI3&mckv=szEgWGgK7_dc%7Cpcrid%7C238407451184%7Cpkw%7C%2Belement14%20%2Bpi%20%2B3%7Cpmt%7Cb%7Cslid%7CE0QUwafP%7Cproduct%7C%7C&gclid=Cj0KCQiAyZLSBRDpARIsAH66VQK5HeckMfiD1iPzSbrMpRJeNTs-IJuUHgCkgFjuTeIZmITQ4rQ6WF0aAnQQEALw_wcB) using a [Hassbian](https://home-assistant.io/docs/installation/hassbian/installation/) image.
 
-Home Assistant Version: 0.65.6
+Home Assistant Version: 0.66.1
 
 ## Platform
 * [Raspberry PI 3 Model B](http://au.element14.com/buy-raspberry-pi?&CMP=KNC-GAU-GEN-SKU-PSP-STL-RPI3&mckv=szEgWGgK7_dc%7Cpcrid%7C238407451184%7Cpkw%7C%2Belement14%20%2Bpi%20%2B3%7Cpmt%7Cb%7Cslid%7CE0QUwafP%7Cproduct%7C%7C&gclid=Cj0KCQiAyZLSBRDpARIsAH66VQK5HeckMfiD1iPzSbrMpRJeNTs-IJuUHgCkgFjuTeIZmITQ4rQ6WF0aAnQQEALw_wcB)

--- a/config/core/packages/twitter.yaml
+++ b/config/core/packages/twitter.yaml
@@ -176,10 +176,8 @@ automation:
             {{ [
             "The number of #Flic presses today was {{states.sensor.flic_presses.state}}",
             "The #lifx lights where on for {{states.sensor.lifx_lights_time.attributes.value}} yesterday.",
-            #"{{states.sensor.captured_today_frontyard.state}} frontdoor events were captured today by #Arlo.",
             "The Pi has been running for {{states.sensor.since_last_boot_templated.state}}",
             "I am running Home Assistant version {{states.sensor.current_version.state}} (https://github.com/Zac300/Home-Assistant-Config)",
-            #"#Arlo captured {{states.sensor.captured_today_backyard.state}} backyard events in the last 24 hours.",
             "Outside is {{states.sensor.dark_sky_temperature.state}}{{states.sensor.dark_sky_apparent_temperature.attributes.unit_of_measurement}}. Currently inside the temperature is {{states.sensor.temperature_158d000201d596.state}}{{states.sensor.temperature_158d000201d596.attributes.unit_of_measurement}}.",
             "My Average #iiNet internet speeds are Download: {{states.sensor.speedtest_download.state}} Mbit/s & Upload {{states.sensor.speedtest_upload.state}} Mbit/s. #NBN",
             "Home Assistant has been running for {{states.sensor.uptime.state}} days. (https://github.com/Zac300/Home-Assistant-Config)",


### PR DESCRIPTION
Target release 0.66.1. Release notes [here](https://www.home-assistant.io/blog/2018/03/30/release-66/#release-0661---april-1)